### PR TITLE
Jumping cursor fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -297,6 +297,15 @@ module.exports = function(grunt) {
                     }
                 ]
             }
+        },
+        connect : {
+            server : {
+                options : {
+                    port : 8081,
+                    base : 'html',
+                    keepalive:true
+                }
+            }
         }
 
     });
@@ -314,6 +323,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-amdcheck');
     grunt.loadNpmTasks('grunt-jsdoc');
     //grunt.loadNpmTasks('grunt-contrib-nodeunit');
+    grunt.loadNpmTasks('grunt-contrib-connect');
 
     // Whenever the "test" task is run, first clean the "tmp" dir, then run this
     // plugin's task(s), then test the result.
@@ -323,5 +333,6 @@ module.exports = function(grunt) {
         grunt.config.set('roleSandboxUrl', "http://role-sandbox.eu");
         grunt.task.run(['clean','requirejs','copy:lib','copy:main','buildwidgets'/*,'sftp'*/]);
     });
+    grunt.registerTask('serve',['clean', 'requirejs', 'copy:lib', 'copy:main', 'buildwidgets','connect']);
 
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-ssh": "~0.7.0",
     "grunt-jsdoc": "~0.5.1",
-    "grunt-amdcheck": "^0.2.1"
+    "grunt-amdcheck": "^0.2.1",
+    "grunt-contrib-connect": "^0.9.0"
   }
 }

--- a/src/js/attribute_widget/Value.js
+++ b/src/js/attribute_widget/Value.js
@@ -99,7 +99,7 @@ define([
                     }
                     break;
             }
-            _$node.val(value).blur();
+            _$node.val(value);
             _$node[0].selectionStart = newSelectionStart;
             _$node[0].selectionEnd = newSelectionEnd;
         };

--- a/src/js/canvas_widget/Value.js
+++ b/src/js/canvas_widget/Value.js
@@ -129,7 +129,7 @@ define([
                     }
                     break;
             }
-            _$node.val(value).blur();
+            _$node.val(value);
             _$node[0].selectionStart = newSelectionStart;
             _$node[0].selectionEnd = newSelectionEnd;
         };


### PR DESCRIPTION
the cursor of a textfield is jumping at the begin of word while editing. This bug seems to occur when you insert something then delete a character and insert something again. I hope this will fix it. 
It also adds a new grunt task to create a simple http server on port 8081 for local testing.
