### PR TITLE
Enum link fix

### DIFF
--- a/.localGruntConfig.json.sample
+++ b/.localGruntConfig.json.sample
@@ -1,4 +1,6 @@
 {
     "baseUrl_use_for_commit" : "https://rwth-acis.github.io/syncmeta/html",
-    "baseUrl" : "http://localhost:8081"
+    "roleSandboxUrl_use_for_commit": "http://role-sandbox.eu",
+    "baseUrl" : "http://127.0.0.1:8081",
+    "roleSandboxUrl": "http://127.0.0.1:8073"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,13 +4,13 @@ module.exports = function(grunt) {
 
     // Project configuration.
     //noinspection JSUnusedGlobalSymbols
-    var localConfig = grunt.file.readJSON('.localGruntConfig.json')
+    var localConfig = grunt.file.readJSON('.localGruntConfig.json');
     grunt.initConfig({
 
         pkg: grunt.file.readJSON('package.json'),
 
         baseUrl: localConfig.baseUrl,
-        roleSandboxUrl: "http://role-sandbox.eu",
+        roleSandboxUrl: localConfig.roleSandboxUrl,
 
         bowerdir: grunt.file.readJSON('.bowerrc')['directory'],
         distdir: 'html',

--- a/src/js/canvas_widget/EntityManager.js
+++ b/src/js/canvas_widget/EntityManager.js
@@ -623,7 +623,7 @@ define([
                  */
                 function getNodeAttributes(node,visitedNodes){
                     var nodeAttributes, attributeId, attribute;
-                    var edgeId, edge, outgoingEdges;
+                    var edgeId, edge, edges;
                     var source, target;
                     var neighbor, options;
                     var attributes = {};
@@ -635,11 +635,11 @@ define([
 
                     visitedNodes.push(node);
 
-                    //Traverse outgoing edges to check for inheritance and linked enums
-                    outgoingEdges = node.getOutgoingEdges();
-                    for(edgeId in outgoingEdges){
-                        if(outgoingEdges.hasOwnProperty(edgeId)){
-                            edge = outgoingEdges[edgeId];
+                    //Traverse edges to check for inheritance and linked enums
+                    edges = node.getEdges();
+                    for(edgeId in edges){
+                        if(edges.hasOwnProperty(edgeId)){
+                            edge = edges[edgeId];
                             source = edge.getSource();
                             target = edge.getTarget();
 


### PR DESCRIPTION
Fix for [SYNCMETA-7](http://layers.dbis.rwth-aachen.de/jira/browse/SYNCMETA-7).
The roleSandboxUrl moved to the localConfig.json, because it is necessary to adjust the url for the generate instance widget to work properly during local development.
