### PR TITLE
Fix issue with metamodel export when the model data contains # characters

### DIFF
--- a/src/js/debug_widget.js
+++ b/src/js/debug_widget.js
@@ -86,7 +86,7 @@ requirejs(['jqueryui', 'lodash', 'lib/yjs-sync', 'canvas_widget/GenerateViewpoin
             $exportModel.click(function () {
                 var link = document.createElement('a');
                 link.download = "model.json";
-                link.href = 'data:,' + encodeURI(JSON.stringify(y.share.data.get('model'), null, 4));
+                link.href = 'data:,' + encodeURIComponent(JSON.stringify(y.share.data.get('model'), null, 4));
                 link.click();
             });
 


### PR DESCRIPTION
After clicking the *Import/Export/Delete a (Meta- or Guidance-)Model* button in the debug widget the resulting downloaded file might be incomplete. This happens because #- characters are not escaped in the link's href tag. Therefore all subsequent content after the first "#" is not included into the file.

Hint: Other export buttons might also be affected by this bug.