### PR TITLE
Fixed bug where nodes and edges disappear

### DIFF
--- a/widgets/src/js/canvas_widget/BooleanValue.js
+++ b/widgets/src/js/canvas_widget/BooleanValue.js
@@ -132,7 +132,7 @@ define([
                     _iwcw.sendLocalOTOperation(CONFIG.WIDGET.NAME.GUIDANCE, operation.getOTOperation());
                     processValueChangeOperation(operation);
 
-                    //Only the local user Propagates the activity and saves the state of the model
+                    //Only the local user Propagates the activity
                     if (_iwcw.getUser()[CONFIG.NS.PERSON.JABBERID] === operation.getJabberId()) {
                         y.share.activity.set(ActivityOperation.TYPE, new ActivityOperation(
                             "ValueChangeActivity",
@@ -146,7 +146,6 @@ define([
                                 rootSubjectEntityId: that.getRootSubjectEntity().getEntityId()
                             }
                         ));
-                        $('#save').click();
                     } else {
                         //the remote users propagtes the change to their local attribute widget
                         //TODO(PENDING): can be replace with yjs as well
@@ -154,6 +153,12 @@ define([
                     }
                 }
             });
+
+            //Debounce the save function
+            that.getRootSubjectEntity().getYMap().observePath([that.getEntityId()], _.debounce(function (event) {
+                if (event && event.jabberId === _iwcw.getUser()[CONFIG.NS.PERSON.JABBERID])
+                    $('#save').click();
+            }, 500));
         };
 
         init();

--- a/widgets/src/js/canvas_widget/IntegerValue.js
+++ b/widgets/src/js/canvas_widget/IntegerValue.js
@@ -134,7 +134,7 @@ define([
                     _iwcw.sendLocalOTOperation(CONFIG.WIDGET.NAME.GUIDANCE, operation.getOTOperation());
                     processValueChangeOperation(operation);
 
-                    //Only the local user Propagates the activity and saves the state of the model
+                    //Only the local user Propagates the activity
                     if (_iwcw.getUser()[CONFIG.NS.PERSON.JABBERID] === operation.getJabberId()) {
                         y.share.activity.set(ActivityOperation.TYPE, new ActivityOperation(
                             "ValueChangeActivity",


### PR DESCRIPTION
This fix is related to the following Jira Issues:
- SYNCMETA-33
- CAE-19 (moved to [GitHub issues](https://github.com/rwth-acis/CAE-Frontend/issues/35))

**Bug description:**
When changing a boolean value (this reason was initially not clear) some nodes and edges were missing when reloading the page / when reloading the model.

**Reason why the bug occured:**
When reloading the page, the JSONtoGraph function creates the nodes and edges which are part of the JSON model.
This means, that the nodes and edges stored in the model (in the Yjs room) are added to the canvas.
During a for-loop which iterates over all the nodes from the model and adds them to the graph, at some point the event listener of BooleanValue is called and calls the "save-function" of SyncMeta.
The entity manager then calls graphToJSON to create a JSON model from the current graph. Since this graph does not contain all the nodes and edges yet (for-loop over nodes has not finished yet), an incorrect model is stored in Yjs.
This led to the bug, that when we reload the page again, the incorrect model is used and some edges and nodes are missing.

**Fix:**
The function call of "save" in BooleanValue's event listener was moved into a "debounce" function in [this commit](https://github.com/rwth-acis/syncmeta/commit/7787ef0244ad210f3c1aa592ff8c8016e5abe76e).
This results in the "save"-function being called after all the nodes and edges were added to the graph/canvas.

The fix was tested both in SyncMeta as well as the CAE.
