### PR TITLE
Generate HTML for test widget (#45)

### DIFF
--- a/widgets/Gruntfile.js
+++ b/widgets/Gruntfile.js
@@ -348,7 +348,17 @@ module.exports = function(grunt) {
                 files: {
                     'html/test.xml': ['<%= srcdir %>/widgets/widget.xml.tpl']
                 }
+            },
 
+            test_widget_html: {
+                options: {
+                    data: {
+                        bodyPartial: '_test_widget.tpl'
+                    }
+                },
+                files: {
+                    'html/test.html': ['<%= srcdir %>/widgets/widget.html.tpl']
+                }
             }
         },
 


### PR DESCRIPTION
This PR is related to issue https://github.com/rwth-acis/syncmeta/issues/45.
It updates the Gruntfile by adding a new task which generates the HTML file for the (already existing) test widget.
This allows adding the widget to the SyncMeta frontend to run the tests.